### PR TITLE
Add Flag=MGF_INPUT_20_BYTE so john detects hashes

### DIFF
--- a/john.local.conf
+++ b/john.local.conf
@@ -2,6 +2,7 @@
 [List.Generic:dynamic_1405]
 Expression=sha1(unicode(CONST1.$p)) [McAfee]
 Flag=MGF_NOTSSE2Safe
+Flag=MGF_INPUT_20_BYTE
 CONST1=\x01\x0f\x0d\x33
 Func=DynamicFunc__clean_input
 Func=DynamicFunc__setmode_unicode


### PR DESCRIPTION
John wasn't detecting the McAfee hashes for me, I had to add the `MGF_INPUT_20_BYTE` flag for it to pick them up.
